### PR TITLE
Convert LatestRound Query to Subscription

### DIFF
--- a/pkg/cache/latest_round.go
+++ b/pkg/cache/latest_round.go
@@ -1,0 +1,27 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/scorify/backend/pkg/ent"
+)
+
+const (
+	// LatestRoundChannel is the key for the latest round pub/sub in redis
+	latestRoundChannel = "latest_round_channel"
+)
+
+func PublishLatestRound(ctx context.Context, redisClient *redis.Client, entRound *ent.Round) (*redis.IntCmd, error) {
+	out, err := json.Marshal(entRound)
+	if err != nil {
+		return nil, err
+	}
+
+	return redisClient.Publish(ctx, latestRoundChannel, out), nil
+}
+
+func SubscribeLatestRound(ctx context.Context, redisClient *redis.Client) *redis.PubSub {
+	return redisClient.Subscribe(ctx, latestRoundChannel)
+}

--- a/pkg/cache/latest_round.go
+++ b/pkg/cache/latest_round.go
@@ -14,6 +14,11 @@ const (
 )
 
 func PublishLatestRound(ctx context.Context, redisClient *redis.Client, entRound *ent.Round) (*redis.IntCmd, error) {
+	err := SetObject(ctx, redisClient, LatestRoundObjectKey, entRound, 0)
+	if err != nil {
+		return nil, err
+	}
+
 	out, err := json.Marshal(entRound)
 	if err != nil {
 		return nil, err

--- a/pkg/engine/main.go
+++ b/pkg/engine/main.go
@@ -178,7 +178,7 @@ func (e *Client) loopRoundRunner() error {
 		return err
 	}
 
-	err = cache.SetObject(roundCtx, e.redis, cache.LatestRoundObjectKey, entRound, 0)
+	_, err = cache.PublishLatestRound(roundCtx, e.redis, entRound)
 	if err != nil {
 		logrus.WithError(err).Error("failed to set latest round object")
 		return err

--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -127,16 +127,15 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Check       func(childComplexity int, id *uuid.UUID, name *string) int
-		Checks      func(childComplexity int) int
-		Config      func(childComplexity int, id uuid.UUID) int
-		Configs     func(childComplexity int) int
-		LatestRound func(childComplexity int) int
-		Me          func(childComplexity int) int
-		Scoreboard  func(childComplexity int, round *int) int
-		Source      func(childComplexity int, name string) int
-		Sources     func(childComplexity int) int
-		Users       func(childComplexity int) int
+		Check      func(childComplexity int, id *uuid.UUID, name *string) int
+		Checks     func(childComplexity int) int
+		Config     func(childComplexity int, id uuid.UUID) int
+		Configs    func(childComplexity int) int
+		Me         func(childComplexity int) int
+		Scoreboard func(childComplexity int, round *int) int
+		Source     func(childComplexity int, name string) int
+		Sources    func(childComplexity int) int
+		Users      func(childComplexity int) int
 	}
 
 	Round struct {
@@ -258,7 +257,6 @@ type QueryResolver interface {
 	Configs(ctx context.Context) ([]*ent.CheckConfig, error)
 	Config(ctx context.Context, id uuid.UUID) (*ent.CheckConfig, error)
 	Scoreboard(ctx context.Context, round *int) (*model.Scoreboard, error)
-	LatestRound(ctx context.Context) (*ent.Round, error)
 }
 type RoundResolver interface {
 	Statuses(ctx context.Context, obj *ent.Round) ([]*ent.Status, error)
@@ -716,13 +714,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Configs(childComplexity), true
-
-	case "Query.latestRound":
-		if e.complexity.Query.LatestRound == nil {
-			break
-		}
-
-		return e.complexity.Query.LatestRound(childComplexity), true
 
 	case "Query.me":
 		if e.complexity.Query.Me == nil {
@@ -5120,66 +5111,6 @@ func (ec *executionContext) fieldContext_Query_scoreboard(ctx context.Context, f
 	if fc.Args, err = ec.field_Query_scoreboard_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_latestRound(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_latestRound(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().LatestRound(rctx)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*ent.Round)
-	fc.Result = res
-	return ec.marshalNRound2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋentᚐRound(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_latestRound(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Round_id(ctx, field)
-			case "number":
-				return ec.fieldContext_Round_number(ctx, field)
-			case "complete":
-				return ec.fieldContext_Round_complete(ctx, field)
-			case "create_time":
-				return ec.fieldContext_Round_create_time(ctx, field)
-			case "update_time":
-				return ec.fieldContext_Round_update_time(ctx, field)
-			case "statuses":
-				return ec.fieldContext_Round_statuses(ctx, field)
-			case "score_caches":
-				return ec.fieldContext_Round_score_caches(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Round", field.Name)
-		},
 	}
 	return fc, nil
 }
@@ -10673,28 +10604,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_scoreboard(ctx, field)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx,
-					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "latestRound":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_latestRound(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -163,7 +163,6 @@ type Query {
   config(id: ID!): Config! @isAuthenticated
 
   scoreboard(round: Int): Scoreboard!
-  latestRound: Round!
 }
 
 type Mutation {

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -146,6 +146,7 @@ type Subscription {
   globalNotification: Notification!
   engineState: EngineState!
   scoreboardUpdate: Scoreboard!
+  latestRound: Round!
 }
 
 type Query {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1115,6 +1115,11 @@ func (r *subscriptionResolver) LatestRound(ctx context.Context) (<-chan *ent.Rou
 	latestRoundChan := make(chan *ent.Round, 1)
 
 	go func() {
+		latestRound := &ent.Round{}
+		if cache.GetObject(ctx, r.Redis, cache.LatestRoundObjectKey, latestRound) {
+			latestRoundChan <- latestRound
+		}
+
 		latestRoundSub := cache.SubscribeLatestRound(ctx, r.Redis)
 		latestRoundSubChan := latestRoundSub.Channel()
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1173,35 +1173,3 @@ type scoreCacheResolver struct{ *Resolver }
 type statusResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *queryResolver) LatestRound(ctx context.Context) (*ent.Round, error) {
-	entRound := &ent.Round{}
-
-	if cache.GetObject(ctx, r.Redis, cache.LatestRoundObjectKey, entRound) {
-		return entRound, nil
-	}
-
-	entRound, err := r.Ent.Round.Query().
-		Order(
-			ent.Desc(
-				round.FieldNumber,
-			),
-		).
-		First(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = cache.SetObject(ctx, r.Redis, cache.LatestRoundObjectKey, entRound, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	return entRound, nil
-}

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -945,33 +945,6 @@ func (r *queryResolver) Scoreboard(ctx context.Context, round *int) (*model.Scor
 	return scoreboard, nil
 }
 
-// LatestRound is the resolver for the latestRound field.
-func (r *queryResolver) LatestRound(ctx context.Context) (*ent.Round, error) {
-	entRound := &ent.Round{}
-
-	if cache.GetObject(ctx, r.Redis, cache.LatestRoundObjectKey, entRound) {
-		return entRound, nil
-	}
-
-	entRound, err := r.Ent.Round.Query().
-		Order(
-			ent.Desc(
-				round.FieldNumber,
-			),
-		).
-		First(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = cache.SetObject(ctx, r.Redis, cache.LatestRoundObjectKey, entRound, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	return entRound, nil
-}
-
 // Statuses is the resolver for the statuses field.
 func (r *roundResolver) Statuses(ctx context.Context, obj *ent.Round) ([]*ent.Status, error) {
 	return r.Ent.Status.Query().
@@ -1200,3 +1173,35 @@ type scoreCacheResolver struct{ *Resolver }
 type statusResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type userResolver struct{ *Resolver }
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *queryResolver) LatestRound(ctx context.Context) (*ent.Round, error) {
+	entRound := &ent.Round{}
+
+	if cache.GetObject(ctx, r.Redis, cache.LatestRoundObjectKey, entRound) {
+		return entRound, nil
+	}
+
+	entRound, err := r.Ent.Round.Query().
+		Order(
+			ent.Desc(
+				round.FieldNumber,
+			),
+		).
+		First(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cache.SetObject(ctx, r.Redis, cache.LatestRoundObjectKey, entRound, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return entRound, nil
+}

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1110,6 +1110,11 @@ func (r *subscriptionResolver) ScoreboardUpdate(ctx context.Context) (<-chan *mo
 	return scoreboardUpdateChan, nil
 }
 
+// LatestRound is the resolver for the latestRound field.
+func (r *subscriptionResolver) LatestRound(ctx context.Context) (<-chan *ent.Round, error) {
+	panic(fmt.Errorf("not implemented: LatestRound - latestRound"))
+}
+
 // Configs is the resolver for the configs field.
 func (r *userResolver) Configs(ctx context.Context, obj *ent.User) ([]*ent.CheckConfig, error) {
 	return obj.QueryConfigs().All(ctx)


### PR DESCRIPTION
Add latestRound field to Subscription type in schema.graphqls

Add LatestRound resolver to Subscription type in schema.graphqls

Add Cache Functions for LatestRound pub/sub

Refactor LatestRound resolver to use cache for pub/sub

Refactor LatestRound resolver to use cache for pub/sub and add latestRound field to Subscription type in schema.graphqls

Refactor LatestRound resolver to use cache for pub/sub and update Subscription type in schema.graphqls