### PR TITLE
Separate Adding and Removing Files from `UpdateInject` Mutation

### DIFF
--- a/pkg/cmd/server/main.go
+++ b/pkg/cmd/server/main.go
@@ -92,7 +92,7 @@ func graphqlHandler(entClient *ent.Client, redisClient *redis.Client, engineClie
 
 func injectFileHandler(entClient *ent.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		entUser, err := auth.Parse(c)
+		entUser, err := auth.Parse(c.Request.Context())
 		if err != nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 			return
@@ -170,7 +170,7 @@ func injectFileHandler(entClient *ent.Client) gin.HandlerFunc {
 
 func injectSubmissionFileHandler(entClient *ent.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		entUser, err := auth.Parse(c)
+		entUser, err := auth.Parse(c.Request.Context())
 		if err != nil {
 			fmt.Println("here")
 			c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})

--- a/pkg/cmd/server/main.go
+++ b/pkg/cmd/server/main.go
@@ -135,8 +135,7 @@ func injectFileHandler(entClient *ent.Client) gin.HandlerFunc {
 				Only(c)
 		}
 		if err != nil {
-			logrus.WithError(err).Error("failed to get inject")
-			c.JSON(http.StatusNotFound, gin.H{"error": "inject not found"})
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("inject not found: %s", err.Error())})
 			return
 		}
 
@@ -159,8 +158,7 @@ func injectFileHandler(entClient *ent.Client) gin.HandlerFunc {
 
 		filePath, err := file.FilePath(structs.FileTypeInject, parentUUID)
 		if err != nil {
-			logrus.WithError(err).Error("failed to get file path")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get file path: %s", err.Error())})
 			return
 		}
 
@@ -172,7 +170,6 @@ func injectSubmissionFileHandler(entClient *ent.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		entUser, err := auth.Parse(c.Request.Context())
 		if err != nil {
-			fmt.Println("here")
 			c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 			return
 		}
@@ -214,8 +211,7 @@ func injectSubmissionFileHandler(entClient *ent.Client) gin.HandlerFunc {
 				Only(c)
 		}
 		if err != nil {
-			logrus.WithError(err).Error("failed to get inject submission")
-			c.JSON(http.StatusNotFound, gin.H{"error": "inject submission not found"})
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("failed to get inject submission: %s", err.Error())})
 			return
 		}
 
@@ -238,8 +234,7 @@ func injectSubmissionFileHandler(entClient *ent.Client) gin.HandlerFunc {
 
 		filePath, err := file.FilePath(structs.FileTypeSubmission, parentUUID)
 		if err != nil {
-			logrus.WithError(err).Error("failed to get file path")
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to get file path: %s", err.Error())})
 			return
 		}
 

--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -129,6 +129,7 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
+		AddInjectFiles         func(childComplexity int, id uuid.UUID, files []*graphql.Upload) int
 		AdminBecome            func(childComplexity int, id uuid.UUID) int
 		AdminLogin             func(childComplexity int, id uuid.UUID) int
 		ChangePassword         func(childComplexity int, oldPassword string, newPassword string) int
@@ -137,6 +138,7 @@ type ComplexityRoot struct {
 		CreateUser             func(childComplexity int, username string, password string, role user.Role, number *int) int
 		DeleteCheck            func(childComplexity int, id uuid.UUID) int
 		DeleteInject           func(childComplexity int, id uuid.UUID) int
+		DeleteInjectFile       func(childComplexity int, id uuid.UUID, file string) int
 		DeleteUser             func(childComplexity int, id uuid.UUID) int
 		EditConfig             func(childComplexity int, id uuid.UUID, config string) int
 		Login                  func(childComplexity int, username string, password string) int
@@ -145,7 +147,7 @@ type ComplexityRoot struct {
 		StopEngine             func(childComplexity int) int
 		SubmitInject           func(childComplexity int, injectID uuid.UUID, files []*graphql.Upload) int
 		UpdateCheck            func(childComplexity int, id uuid.UUID, name *string, weight *int, config *string, editableFields []string) int
-		UpdateInject           func(childComplexity int, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time, files []*graphql.Upload) int
+		UpdateInject           func(childComplexity int, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time) int
 		UpdateUser             func(childComplexity int, id uuid.UUID, username *string, password *string, number *int) int
 	}
 
@@ -290,7 +292,9 @@ type MutationResolver interface {
 	StartEngine(ctx context.Context) (bool, error)
 	StopEngine(ctx context.Context) (bool, error)
 	CreateInject(ctx context.Context, title string, startTime time.Time, endTime time.Time, files []*graphql.Upload) (*ent.Inject, error)
-	UpdateInject(ctx context.Context, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time, files []*graphql.Upload) (*ent.Inject, error)
+	UpdateInject(ctx context.Context, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time) (*ent.Inject, error)
+	AddInjectFiles(ctx context.Context, id uuid.UUID, files []*graphql.Upload) (*ent.Inject, error)
+	DeleteInjectFile(ctx context.Context, id uuid.UUID, file string) (*ent.Inject, error)
 	DeleteInject(ctx context.Context, id uuid.UUID) (bool, error)
 	SubmitInject(ctx context.Context, injectID uuid.UUID, files []*graphql.Upload) (*ent.InjectSubmission, error)
 }
@@ -669,6 +673,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LoginOutput.Token(childComplexity), true
 
+	case "Mutation.addInjectFiles":
+		if e.complexity.Mutation.AddInjectFiles == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_addInjectFiles_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.AddInjectFiles(childComplexity, args["id"].(uuid.UUID), args["files"].([]*graphql.Upload)), true
+
 	case "Mutation.adminBecome":
 		if e.complexity.Mutation.AdminBecome == nil {
 			break
@@ -764,6 +780,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteInject(childComplexity, args["id"].(uuid.UUID)), true
+
+	case "Mutation.deleteInjectFile":
+		if e.complexity.Mutation.DeleteInjectFile == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteInjectFile_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteInjectFile(childComplexity, args["id"].(uuid.UUID), args["file"].(string)), true
 
 	case "Mutation.deleteUser":
 		if e.complexity.Mutation.DeleteUser == nil {
@@ -861,7 +889,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.UpdateInject(childComplexity, args["id"].(uuid.UUID), args["title"].(*string), args["start_time"].(*time.Time), args["end_time"].(*time.Time), args["files"].([]*graphql.Upload)), true
+		return e.complexity.Mutation.UpdateInject(childComplexity, args["id"].(uuid.UUID), args["title"].(*string), args["start_time"].(*time.Time), args["end_time"].(*time.Time)), true
 
 	case "Mutation.updateUser":
 		if e.complexity.Mutation.UpdateUser == nil {
@@ -1515,6 +1543,30 @@ func (ec *executionContext) dir_hasRole_args(ctx context.Context, rawArgs map[st
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_addInjectFiles_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 uuid.UUID
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	var arg1 []*graphql.Upload
+	if tmp, ok := rawArgs["files"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("files"))
+		arg1, err = ec.unmarshalNUpload2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUploadᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["files"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_adminBecome_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -1716,6 +1768,30 @@ func (ec *executionContext) field_Mutation_deleteCheck_args(ctx context.Context,
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteInjectFile_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 uuid.UUID
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	var arg1 string
+	if tmp, ok := rawArgs["file"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("file"))
+		arg1, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["file"] = arg1
 	return args, nil
 }
 
@@ -1935,15 +2011,6 @@ func (ec *executionContext) field_Mutation_updateInject_args(ctx context.Context
 		}
 	}
 	args["end_time"] = arg3
-	var arg4 []*graphql.Upload
-	if tmp, ok := rawArgs["files"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("files"))
-		arg4, err = ec.unmarshalOUpload2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUploadᚄ(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["files"] = arg4
 	return args, nil
 }
 
@@ -5675,7 +5742,7 @@ func (ec *executionContext) _Mutation_updateInject(ctx context.Context, field gr
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().UpdateInject(rctx, fc.Args["id"].(uuid.UUID), fc.Args["title"].(*string), fc.Args["start_time"].(*time.Time), fc.Args["end_time"].(*time.Time), fc.Args["files"].([]*graphql.Upload))
+			return ec.resolvers.Mutation().UpdateInject(rctx, fc.Args["id"].(uuid.UUID), fc.Args["title"].(*string), fc.Args["start_time"].(*time.Time), fc.Args["end_time"].(*time.Time))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			roles, err := ec.unmarshalORole2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋentᚋuserᚐRole(ctx, []interface{}{"admin"})
@@ -5751,6 +5818,200 @@ func (ec *executionContext) fieldContext_Mutation_updateInject(ctx context.Conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_updateInject_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_addInjectFiles(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_addInjectFiles(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().AddInjectFiles(rctx, fc.Args["id"].(uuid.UUID), fc.Args["files"].([]*graphql.Upload))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			roles, err := ec.unmarshalORole2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋentᚋuserᚐRole(ctx, []interface{}{"admin"})
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasRole == nil {
+				return nil, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*ent.Inject); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/scorify/backend/pkg/ent.Inject`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*ent.Inject)
+	fc.Result = res
+	return ec.marshalNInject2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋentᚐInject(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_addInjectFiles(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Inject_id(ctx, field)
+			case "title":
+				return ec.fieldContext_Inject_title(ctx, field)
+			case "start_time":
+				return ec.fieldContext_Inject_start_time(ctx, field)
+			case "end_time":
+				return ec.fieldContext_Inject_end_time(ctx, field)
+			case "create_time":
+				return ec.fieldContext_Inject_create_time(ctx, field)
+			case "update_time":
+				return ec.fieldContext_Inject_update_time(ctx, field)
+			case "files":
+				return ec.fieldContext_Inject_files(ctx, field)
+			case "submissions":
+				return ec.fieldContext_Inject_submissions(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Inject", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_addInjectFiles_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteInjectFile(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteInjectFile(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		directive0 := func(rctx context.Context) (interface{}, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().DeleteInjectFile(rctx, fc.Args["id"].(uuid.UUID), fc.Args["file"].(string))
+		}
+		directive1 := func(ctx context.Context) (interface{}, error) {
+			roles, err := ec.unmarshalORole2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋentᚋuserᚐRole(ctx, []interface{}{"admin"})
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.HasRole == nil {
+				return nil, errors.New("directive hasRole is not implemented")
+			}
+			return ec.directives.HasRole(ctx, nil, directive0, roles)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*ent.Inject); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/scorify/backend/pkg/ent.Inject`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*ent.Inject)
+	fc.Result = res
+	return ec.marshalNInject2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋentᚐInject(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteInjectFile(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Inject_id(ctx, field)
+			case "title":
+				return ec.fieldContext_Inject_title(ctx, field)
+			case "start_time":
+				return ec.fieldContext_Inject_start_time(ctx, field)
+			case "end_time":
+				return ec.fieldContext_Inject_end_time(ctx, field)
+			case "create_time":
+				return ec.fieldContext_Inject_create_time(ctx, field)
+			case "update_time":
+				return ec.fieldContext_Inject_update_time(ctx, field)
+			case "files":
+				return ec.fieldContext_Inject_files(ctx, field)
+			case "submissions":
+				return ec.fieldContext_Inject_submissions(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Inject", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteInjectFile_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -12615,6 +12876,20 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "addInjectFiles":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_addInjectFiles(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deleteInjectFile":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteInjectFile(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "deleteInject":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteInject(ctx, field)
@@ -15604,44 +15879,6 @@ func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel
 	}
 	res := graphql.MarshalTime(*v)
 	return res
-}
-
-func (ec *executionContext) unmarshalOUpload2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUploadᚄ(ctx context.Context, v interface{}) ([]*graphql.Upload, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var vSlice []interface{}
-	if v != nil {
-		vSlice = graphql.CoerceList(v)
-	}
-	var err error
-	res := make([]*graphql.Upload, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) marshalOUpload2ᚕᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUploadᚄ(ctx context.Context, sel ast.SelectionSet, v []*graphql.Upload) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	for i := range v {
-		ret[i] = ec.marshalNUpload2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚐUpload(ctx, sel, v[i])
-	}
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalOUser2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋentᚐUser(ctx context.Context, sel ast.SelectionSet, v *ent.User) graphql.Marshaler {

--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -96,6 +96,12 @@ type ComplexityRoot struct {
 		User   func(childComplexity int) int
 	}
 
+	File struct {
+		ID   func(childComplexity int) int
+		Name func(childComplexity int) int
+		URL  func(childComplexity int) int
+	}
+
 	Inject struct {
 		CreateTime  func(childComplexity int) int
 		EndTime     func(childComplexity int) int
@@ -267,11 +273,11 @@ type ConfigResolver interface {
 	User(ctx context.Context, obj *ent.CheckConfig) (*ent.User, error)
 }
 type InjectResolver interface {
-	Files(ctx context.Context, obj *ent.Inject) ([]string, error)
+	Files(ctx context.Context, obj *ent.Inject) ([]*model.File, error)
 	Submissions(ctx context.Context, obj *ent.Inject) ([]*ent.InjectSubmission, error)
 }
 type InjectSubmissionResolver interface {
-	Files(ctx context.Context, obj *ent.InjectSubmission) ([]string, error)
+	Files(ctx context.Context, obj *ent.InjectSubmission) ([]*model.File, error)
 
 	User(ctx context.Context, obj *ent.InjectSubmission) (*ent.User, error)
 	Inject(ctx context.Context, obj *ent.InjectSubmission) (*ent.Inject, error)
@@ -511,6 +517,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Config.User(childComplexity), true
+
+	case "File.id":
+		if e.complexity.File.ID == nil {
+			break
+		}
+
+		return e.complexity.File.ID(childComplexity), true
+
+	case "File.name":
+		if e.complexity.File.Name == nil {
+			break
+		}
+
+		return e.complexity.File.Name(childComplexity), true
+
+	case "File.url":
+		if e.complexity.File.URL == nil {
+			break
+		}
+
+		return e.complexity.File.URL(childComplexity), true
 
 	case "Inject.create_time":
 		if e.complexity.Inject.CreateTime == nil {
@@ -3362,6 +3389,138 @@ func (ec *executionContext) fieldContext_Config_user(ctx context.Context, field 
 	return fc, nil
 }
 
+func (ec *executionContext) _File_id(ctx context.Context, field graphql.CollectedField, obj *model.File) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_File_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uuid.UUID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_File_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "File",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _File_name(ctx context.Context, field graphql.CollectedField, obj *model.File) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_File_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_File_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "File",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _File_url(ctx context.Context, field graphql.CollectedField, obj *model.File) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_File_url(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.URL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_File_url(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "File",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Inject_id(ctx context.Context, field graphql.CollectedField, obj *ent.Inject) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Inject_id(ctx, field)
 	if err != nil {
@@ -3652,9 +3811,9 @@ func (ec *executionContext) _Inject_files(ctx context.Context, field graphql.Col
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.([]*model.File)
 	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNFile2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐFileᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Inject_files(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3664,7 +3823,15 @@ func (ec *executionContext) fieldContext_Inject_files(ctx context.Context, field
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_File_id(ctx, field)
+			case "name":
+				return ec.fieldContext_File_name(ctx, field)
+			case "url":
+				return ec.fieldContext_File_url(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type File", field.Name)
 		},
 	}
 	return fc, nil
@@ -3890,9 +4057,9 @@ func (ec *executionContext) _InjectSubmission_files(ctx context.Context, field g
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]string)
+	res := resTmp.([]*model.File)
 	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+	return ec.marshalNFile2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐFileᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_InjectSubmission_files(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -3902,7 +4069,15 @@ func (ec *executionContext) fieldContext_InjectSubmission_files(ctx context.Cont
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_File_id(ctx, field)
+			case "name":
+				return ec.fieldContext_File_name(ctx, field)
+			case "url":
+				return ec.fieldContext_File_url(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type File", field.Name)
 		},
 	}
 	return fc, nil
@@ -12373,6 +12548,55 @@ func (ec *executionContext) _Config(ctx context.Context, sel ast.SelectionSet, o
 	return out
 }
 
+var fileImplementors = []string{"File"}
+
+func (ec *executionContext) _File(ctx context.Context, sel ast.SelectionSet, obj *model.File) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, fileImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("File")
+		case "id":
+			out.Values[i] = ec._File_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._File_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "url":
+			out.Values[i] = ec._File_url(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var injectImplementors = []string{"Inject"}
 
 func (ec *executionContext) _Inject(ctx context.Context, sel ast.SelectionSet, obj *ent.Inject) graphql.Marshaler {
@@ -14652,6 +14876,60 @@ func (ec *executionContext) unmarshalNEngineState2githubᚗcomᚋscorifyᚋbacke
 
 func (ec *executionContext) marshalNEngineState2githubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐEngineState(ctx context.Context, sel ast.SelectionSet, v model.EngineState) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNFile2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐFileᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.File) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNFile2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐFile(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNFile2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐFile(ctx context.Context, sel ast.SelectionSet, v *model.File) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._File(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNID2githubᚗcomᚋgoogleᚋuuidᚐUUID(ctx context.Context, v interface{}) (uuid.UUID, error) {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -7,8 +7,15 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/google/uuid"
 	"github.com/scorify/backend/pkg/ent"
 )
+
+type File struct {
+	ID   uuid.UUID `json:"id"`
+	Name string    `json:"name"`
+	URL  string    `json:"url"`
+}
 
 type LoginOutput struct {
 	Name     string `json:"name"`

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -126,6 +126,12 @@ type Round {
   score_caches: [ScoreCache!]!
 }
 
+type File {
+  id: ID!
+  name: String!
+  url: String!
+}
+
 type Inject {
   id: ID!
   title: String!
@@ -133,7 +139,7 @@ type Inject {
   end_time: Time!
   create_time: Time!
   update_time: Time!
-  files: [String!]!
+  files: [File!]!
   submissions: [InjectSubmission!]!
 }
 
@@ -141,7 +147,7 @@ type InjectSubmission {
   id: ID!
   create_time: Time!
   update_time: Time!
-  files: [String!]!
+  files: [File!]!
   inject_id: ID!
   user_id: ID!
   user: User!

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -246,8 +246,9 @@ type Mutation {
     title: String
     start_time: Time
     end_time: Time
-    files: [Upload!]
   ): Inject! @hasRole(roles: [admin])
+  addInjectFiles(id: ID!, files: [Upload!]!): Inject! @hasRole(roles: [admin])
+  deleteInjectFile(id: ID!, file: String!): Inject! @hasRole(roles: [admin])
   deleteInject(id: ID!): Boolean! @hasRole(roles: [admin])
 
   submitInject(injectID: ID!, files: [Upload!]!): InjectSubmission!

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -107,7 +107,7 @@ func (r *configResolver) User(ctx context.Context, obj *ent.CheckConfig) (*ent.U
 }
 
 // Files is the resolver for the files field.
-func (r *injectResolver) Files(ctx context.Context, obj *ent.Inject) ([]string, error) {
+func (r *injectResolver) Files(ctx context.Context, obj *ent.Inject) ([]*model.File, error) {
 	var err error
 
 	files := make([]string, len(obj.Files))
@@ -129,7 +129,7 @@ func (r *injectResolver) Submissions(ctx context.Context, obj *ent.Inject) ([]*e
 }
 
 // Files is the resolver for the files field.
-func (r *injectSubmissionResolver) Files(ctx context.Context, obj *ent.InjectSubmission) ([]string, error) {
+func (r *injectSubmissionResolver) Files(ctx context.Context, obj *ent.InjectSubmission) ([]*model.File, error) {
 	var err error
 
 	files := make([]string, len(obj.Files))

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -911,18 +911,8 @@ func (r *mutationResolver) CreateInject(ctx context.Context, title string, start
 
 // UpdateInject is the resolver for the updateInject field.
 func (r *mutationResolver) UpdateInject(ctx context.Context, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time) (*ent.Inject, error) {
-	structFiles := make([]structs.File, len(files))
-
-	for i, file := range files {
-		structFiles[i] = structs.File{
-			ID:   uuid.New(),
-			Name: file.Filename,
-		}
-
-		err := structFiles[i].WriteFile(structs.FileTypeInject, id, file.File)
-		if err != nil {
-			return nil, fmt.Errorf("failed to write file: %v", err)
-		}
+	if title == nil && startTime == nil && endTime == nil {
+		return nil, fmt.Errorf("no fields to update")
 	}
 
 	tx, err := r.Ent.Tx(ctx)
@@ -945,8 +935,6 @@ func (r *mutationResolver) UpdateInject(ctx context.Context, id uuid.UUID, title
 	if endTime != nil {
 		injectUpdate.SetEndTime(*endTime)
 	}
-
-	injectUpdate.SetFiles(structFiles)
 
 	entInject, err := injectUpdate.Save(ctx)
 	if err != nil {

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -910,7 +910,7 @@ func (r *mutationResolver) CreateInject(ctx context.Context, title string, start
 }
 
 // UpdateInject is the resolver for the updateInject field.
-func (r *mutationResolver) UpdateInject(ctx context.Context, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time, files []*graphql.Upload) (*ent.Inject, error) {
+func (r *mutationResolver) UpdateInject(ctx context.Context, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time) (*ent.Inject, error) {
 	structFiles := make([]structs.File, len(files))
 
 	for i, file := range files {
@@ -959,6 +959,16 @@ func (r *mutationResolver) UpdateInject(ctx context.Context, id uuid.UUID, title
 	}
 
 	return entInject, nil
+}
+
+// AddInjectFiles is the resolver for the addInjectFiles field.
+func (r *mutationResolver) AddInjectFiles(ctx context.Context, id uuid.UUID, files []*graphql.Upload) (*ent.Inject, error) {
+	panic(fmt.Errorf("not implemented: AddInjectFiles - addInjectFiles"))
+}
+
+// DeleteInjectFile is the resolver for the deleteInjectFile field.
+func (r *mutationResolver) DeleteInjectFile(ctx context.Context, id uuid.UUID, file string) (*ent.Inject, error) {
+	panic(fmt.Errorf("not implemented: DeleteInjectFile - deleteInjectFile"))
 }
 
 // DeleteInject is the resolver for the deleteInject field.

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -134,14 +134,18 @@ func (r *injectResolver) Submissions(ctx context.Context, obj *ent.Inject) ([]*e
 
 // Files is the resolver for the files field.
 func (r *injectSubmissionResolver) Files(ctx context.Context, obj *ent.InjectSubmission) ([]*model.File, error) {
-	var err error
-
-	files := make([]string, len(obj.Files))
+	files := make([]*model.File, len(obj.Files))
 
 	for i, file := range obj.Files {
-		files[i], err = file.APIPath(structs.FileTypeSubmission, obj.ID)
+		url, err := file.APIPath(structs.FileTypeSubmission, obj.ID)
 		if err != nil {
 			logrus.Errorf("failed to get file path: %v", err)
+		}
+
+		files[i] = &model.File{
+			ID:   file.ID,
+			Name: file.Name,
+			URL:  url,
 		}
 	}
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -108,14 +108,18 @@ func (r *configResolver) User(ctx context.Context, obj *ent.CheckConfig) (*ent.U
 
 // Files is the resolver for the files field.
 func (r *injectResolver) Files(ctx context.Context, obj *ent.Inject) ([]*model.File, error) {
-	var err error
-
-	files := make([]string, len(obj.Files))
+	files := make([]*model.File, len(obj.Files))
 
 	for i, file := range obj.Files {
-		files[i], err = file.APIPath(structs.FileTypeInject, obj.ID)
+		url, err := file.APIPath(structs.FileTypeInject, obj.ID)
 		if err != nil {
 			logrus.Errorf("failed to get file path: %v", err)
+		}
+
+		files[i] = &model.File{
+			ID:   file.ID,
+			Name: file.Name,
+			URL:  url,
 		}
 
 	}


### PR DESCRIPTION
Add addInjectFiles and deleteInjectFile mutations to schema.graphqls

gql generation

Refactor UpdateInject resolver to handle empty update fields in schema.resolvers.go

Refactor AddInjectFiles resolver to handle file uploads and update inject files in schema.resolvers.go

Refactor Inject and InjectSubmission resolvers to handle file uploads and update schema in schema.resolvers.go

gql generation

Refactor Inject resolver to use model.File struct for file representation in schema.resolvers.go

Refactor InjectSubmission resolver to use model.File struct for file representation in schema.resolvers.go