### PR TITLE
Add Rubric to Injects and InjectSubmissions

### DIFF
--- a/pkg/ent/inject.go
+++ b/pkg/ent/inject.go
@@ -34,7 +34,7 @@ type Inject struct {
 	// The files of the inject
 	Files []structs.File `json:"files"`
 	// The rubric of the inject
-	Rubric structs.Rubric `json:"rubric"`
+	Rubric structs.RubricTemplate `json:"rubric"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the InjectQuery when eager-loading is set.
 	Edges        InjectEdges `json:"edges"`

--- a/pkg/ent/inject/inject.go
+++ b/pkg/ent/inject/inject.go
@@ -27,6 +27,8 @@ const (
 	FieldEndTime = "end_time"
 	// FieldFiles holds the string denoting the files field in the database.
 	FieldFiles = "files"
+	// FieldRubric holds the string denoting the rubric field in the database.
+	FieldRubric = "rubric"
 	// EdgeSubmissions holds the string denoting the submissions edge name in mutations.
 	EdgeSubmissions = "submissions"
 	// Table holds the table name of the inject in the database.
@@ -49,6 +51,7 @@ var Columns = []string{
 	FieldStartTime,
 	FieldEndTime,
 	FieldFiles,
+	FieldRubric,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).

--- a/pkg/ent/inject_create.go
+++ b/pkg/ent/inject_create.go
@@ -76,8 +76,8 @@ func (ic *InjectCreate) SetFiles(s []structs.File) *InjectCreate {
 }
 
 // SetRubric sets the "rubric" field.
-func (ic *InjectCreate) SetRubric(s structs.Rubric) *InjectCreate {
-	ic.mutation.SetRubric(s)
+func (ic *InjectCreate) SetRubric(st structs.RubricTemplate) *InjectCreate {
+	ic.mutation.SetRubric(st)
 	return ic
 }
 

--- a/pkg/ent/inject_create.go
+++ b/pkg/ent/inject_create.go
@@ -75,6 +75,12 @@ func (ic *InjectCreate) SetFiles(s []structs.File) *InjectCreate {
 	return ic
 }
 
+// SetRubric sets the "rubric" field.
+func (ic *InjectCreate) SetRubric(s structs.Rubric) *InjectCreate {
+	ic.mutation.SetRubric(s)
+	return ic
+}
+
 // SetID sets the "id" field.
 func (ic *InjectCreate) SetID(u uuid.UUID) *InjectCreate {
 	ic.mutation.SetID(u)
@@ -178,6 +184,9 @@ func (ic *InjectCreate) check() error {
 	if _, ok := ic.mutation.Files(); !ok {
 		return &ValidationError{Name: "files", err: errors.New(`ent: missing required field "Inject.files"`)}
 	}
+	if _, ok := ic.mutation.Rubric(); !ok {
+		return &ValidationError{Name: "rubric", err: errors.New(`ent: missing required field "Inject.rubric"`)}
+	}
 	return nil
 }
 
@@ -236,6 +245,10 @@ func (ic *InjectCreate) createSpec() (*Inject, *sqlgraph.CreateSpec) {
 	if value, ok := ic.mutation.Files(); ok {
 		_spec.SetField(inject.FieldFiles, field.TypeJSON, value)
 		_node.Files = value
+	}
+	if value, ok := ic.mutation.Rubric(); ok {
+		_spec.SetField(inject.FieldRubric, field.TypeJSON, value)
+		_node.Rubric = value
 	}
 	if nodes := ic.mutation.SubmissionsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/ent/inject_update.go
+++ b/pkg/ent/inject_update.go
@@ -92,6 +92,20 @@ func (iu *InjectUpdate) AppendFiles(s []structs.File) *InjectUpdate {
 	return iu
 }
 
+// SetRubric sets the "rubric" field.
+func (iu *InjectUpdate) SetRubric(s structs.Rubric) *InjectUpdate {
+	iu.mutation.SetRubric(s)
+	return iu
+}
+
+// SetNillableRubric sets the "rubric" field if the given value is not nil.
+func (iu *InjectUpdate) SetNillableRubric(s *structs.Rubric) *InjectUpdate {
+	if s != nil {
+		iu.SetRubric(*s)
+	}
+	return iu
+}
+
 // AddSubmissionIDs adds the "submissions" edge to the InjectSubmission entity by IDs.
 func (iu *InjectUpdate) AddSubmissionIDs(ids ...uuid.UUID) *InjectUpdate {
 	iu.mutation.AddSubmissionIDs(ids...)
@@ -210,6 +224,9 @@ func (iu *InjectUpdate) sqlSave(ctx context.Context) (n int, err error) {
 		_spec.AddModifier(func(u *sql.UpdateBuilder) {
 			sqljson.Append(u, inject.FieldFiles, value)
 		})
+	}
+	if value, ok := iu.mutation.Rubric(); ok {
+		_spec.SetField(inject.FieldRubric, field.TypeJSON, value)
 	}
 	if iu.mutation.SubmissionsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -333,6 +350,20 @@ func (iuo *InjectUpdateOne) SetFiles(s []structs.File) *InjectUpdateOne {
 // AppendFiles appends s to the "files" field.
 func (iuo *InjectUpdateOne) AppendFiles(s []structs.File) *InjectUpdateOne {
 	iuo.mutation.AppendFiles(s)
+	return iuo
+}
+
+// SetRubric sets the "rubric" field.
+func (iuo *InjectUpdateOne) SetRubric(s structs.Rubric) *InjectUpdateOne {
+	iuo.mutation.SetRubric(s)
+	return iuo
+}
+
+// SetNillableRubric sets the "rubric" field if the given value is not nil.
+func (iuo *InjectUpdateOne) SetNillableRubric(s *structs.Rubric) *InjectUpdateOne {
+	if s != nil {
+		iuo.SetRubric(*s)
+	}
 	return iuo
 }
 
@@ -484,6 +515,9 @@ func (iuo *InjectUpdateOne) sqlSave(ctx context.Context) (_node *Inject, err err
 		_spec.AddModifier(func(u *sql.UpdateBuilder) {
 			sqljson.Append(u, inject.FieldFiles, value)
 		})
+	}
+	if value, ok := iuo.mutation.Rubric(); ok {
+		_spec.SetField(inject.FieldRubric, field.TypeJSON, value)
 	}
 	if iuo.mutation.SubmissionsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/ent/inject_update.go
+++ b/pkg/ent/inject_update.go
@@ -93,15 +93,15 @@ func (iu *InjectUpdate) AppendFiles(s []structs.File) *InjectUpdate {
 }
 
 // SetRubric sets the "rubric" field.
-func (iu *InjectUpdate) SetRubric(s structs.Rubric) *InjectUpdate {
-	iu.mutation.SetRubric(s)
+func (iu *InjectUpdate) SetRubric(st structs.RubricTemplate) *InjectUpdate {
+	iu.mutation.SetRubric(st)
 	return iu
 }
 
 // SetNillableRubric sets the "rubric" field if the given value is not nil.
-func (iu *InjectUpdate) SetNillableRubric(s *structs.Rubric) *InjectUpdate {
-	if s != nil {
-		iu.SetRubric(*s)
+func (iu *InjectUpdate) SetNillableRubric(st *structs.RubricTemplate) *InjectUpdate {
+	if st != nil {
+		iu.SetRubric(*st)
 	}
 	return iu
 }
@@ -354,15 +354,15 @@ func (iuo *InjectUpdateOne) AppendFiles(s []structs.File) *InjectUpdateOne {
 }
 
 // SetRubric sets the "rubric" field.
-func (iuo *InjectUpdateOne) SetRubric(s structs.Rubric) *InjectUpdateOne {
-	iuo.mutation.SetRubric(s)
+func (iuo *InjectUpdateOne) SetRubric(st structs.RubricTemplate) *InjectUpdateOne {
+	iuo.mutation.SetRubric(st)
 	return iuo
 }
 
 // SetNillableRubric sets the "rubric" field if the given value is not nil.
-func (iuo *InjectUpdateOne) SetNillableRubric(s *structs.Rubric) *InjectUpdateOne {
-	if s != nil {
-		iuo.SetRubric(*s)
+func (iuo *InjectUpdateOne) SetNillableRubric(st *structs.RubricTemplate) *InjectUpdateOne {
+	if st != nil {
+		iuo.SetRubric(*st)
 	}
 	return iuo
 }

--- a/pkg/ent/injectsubmission/injectsubmission.go
+++ b/pkg/ent/injectsubmission/injectsubmission.go
@@ -25,6 +25,10 @@ const (
 	FieldInjectID = "inject_id"
 	// FieldUserID holds the string denoting the user_id field in the database.
 	FieldUserID = "user_id"
+	// FieldNotes holds the string denoting the notes field in the database.
+	FieldNotes = "notes"
+	// FieldRubric holds the string denoting the rubric field in the database.
+	FieldRubric = "rubric"
 	// EdgeInject holds the string denoting the inject edge name in mutations.
 	EdgeInject = "inject"
 	// EdgeUser holds the string denoting the user edge name in mutations.
@@ -55,6 +59,8 @@ var Columns = []string{
 	FieldFiles,
 	FieldInjectID,
 	FieldUserID,
+	FieldNotes,
+	FieldRubric,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -104,6 +110,11 @@ func ByInjectID(opts ...sql.OrderTermOption) OrderOption {
 // ByUserID orders the results by the user_id field.
 func ByUserID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUserID, opts...).ToFunc()
+}
+
+// ByNotes orders the results by the notes field.
+func ByNotes(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldNotes, opts...).ToFunc()
 }
 
 // ByInjectField orders the results by inject field.

--- a/pkg/ent/injectsubmission/where.go
+++ b/pkg/ent/injectsubmission/where.go
@@ -76,6 +76,11 @@ func UserID(v uuid.UUID) predicate.InjectSubmission {
 	return predicate.InjectSubmission(sql.FieldEQ(FieldUserID, v))
 }
 
+// Notes applies equality check predicate on the "notes" field. It's identical to NotesEQ.
+func Notes(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldEQ(FieldNotes, v))
+}
+
 // CreateTimeEQ applies the EQ predicate on the "create_time" field.
 func CreateTimeEQ(v time.Time) predicate.InjectSubmission {
 	return predicate.InjectSubmission(sql.FieldEQ(FieldCreateTime, v))
@@ -194,6 +199,71 @@ func UserIDIn(vs ...uuid.UUID) predicate.InjectSubmission {
 // UserIDNotIn applies the NotIn predicate on the "user_id" field.
 func UserIDNotIn(vs ...uuid.UUID) predicate.InjectSubmission {
 	return predicate.InjectSubmission(sql.FieldNotIn(FieldUserID, vs...))
+}
+
+// NotesEQ applies the EQ predicate on the "notes" field.
+func NotesEQ(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldEQ(FieldNotes, v))
+}
+
+// NotesNEQ applies the NEQ predicate on the "notes" field.
+func NotesNEQ(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldNEQ(FieldNotes, v))
+}
+
+// NotesIn applies the In predicate on the "notes" field.
+func NotesIn(vs ...string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldIn(FieldNotes, vs...))
+}
+
+// NotesNotIn applies the NotIn predicate on the "notes" field.
+func NotesNotIn(vs ...string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldNotIn(FieldNotes, vs...))
+}
+
+// NotesGT applies the GT predicate on the "notes" field.
+func NotesGT(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldGT(FieldNotes, v))
+}
+
+// NotesGTE applies the GTE predicate on the "notes" field.
+func NotesGTE(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldGTE(FieldNotes, v))
+}
+
+// NotesLT applies the LT predicate on the "notes" field.
+func NotesLT(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldLT(FieldNotes, v))
+}
+
+// NotesLTE applies the LTE predicate on the "notes" field.
+func NotesLTE(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldLTE(FieldNotes, v))
+}
+
+// NotesContains applies the Contains predicate on the "notes" field.
+func NotesContains(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldContains(FieldNotes, v))
+}
+
+// NotesHasPrefix applies the HasPrefix predicate on the "notes" field.
+func NotesHasPrefix(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldHasPrefix(FieldNotes, v))
+}
+
+// NotesHasSuffix applies the HasSuffix predicate on the "notes" field.
+func NotesHasSuffix(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldHasSuffix(FieldNotes, v))
+}
+
+// NotesEqualFold applies the EqualFold predicate on the "notes" field.
+func NotesEqualFold(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldEqualFold(FieldNotes, v))
+}
+
+// NotesContainsFold applies the ContainsFold predicate on the "notes" field.
+func NotesContainsFold(v string) predicate.InjectSubmission {
+	return predicate.InjectSubmission(sql.FieldContainsFold(FieldNotes, v))
 }
 
 // HasInject applies the HasEdge predicate on the "inject" edge.

--- a/pkg/ent/injectsubmission_create.go
+++ b/pkg/ent/injectsubmission_create.go
@@ -70,6 +70,18 @@ func (isc *InjectSubmissionCreate) SetUserID(u uuid.UUID) *InjectSubmissionCreat
 	return isc
 }
 
+// SetNotes sets the "notes" field.
+func (isc *InjectSubmissionCreate) SetNotes(s string) *InjectSubmissionCreate {
+	isc.mutation.SetNotes(s)
+	return isc
+}
+
+// SetRubric sets the "rubric" field.
+func (isc *InjectSubmissionCreate) SetRubric(s structs.Rubric) *InjectSubmissionCreate {
+	isc.mutation.SetRubric(s)
+	return isc
+}
+
 // SetID sets the "id" field.
 func (isc *InjectSubmissionCreate) SetID(u uuid.UUID) *InjectSubmissionCreate {
 	isc.mutation.SetID(u)
@@ -160,6 +172,12 @@ func (isc *InjectSubmissionCreate) check() error {
 	if _, ok := isc.mutation.UserID(); !ok {
 		return &ValidationError{Name: "user_id", err: errors.New(`ent: missing required field "InjectSubmission.user_id"`)}
 	}
+	if _, ok := isc.mutation.Notes(); !ok {
+		return &ValidationError{Name: "notes", err: errors.New(`ent: missing required field "InjectSubmission.notes"`)}
+	}
+	if _, ok := isc.mutation.Rubric(); !ok {
+		return &ValidationError{Name: "rubric", err: errors.New(`ent: missing required field "InjectSubmission.rubric"`)}
+	}
 	if _, ok := isc.mutation.InjectID(); !ok {
 		return &ValidationError{Name: "inject", err: errors.New(`ent: missing required edge "InjectSubmission.inject"`)}
 	}
@@ -212,6 +230,14 @@ func (isc *InjectSubmissionCreate) createSpec() (*InjectSubmission, *sqlgraph.Cr
 	if value, ok := isc.mutation.Files(); ok {
 		_spec.SetField(injectsubmission.FieldFiles, field.TypeJSON, value)
 		_node.Files = value
+	}
+	if value, ok := isc.mutation.Notes(); ok {
+		_spec.SetField(injectsubmission.FieldNotes, field.TypeString, value)
+		_node.Notes = value
+	}
+	if value, ok := isc.mutation.Rubric(); ok {
+		_spec.SetField(injectsubmission.FieldRubric, field.TypeJSON, value)
+		_node.Rubric = value
 	}
 	if nodes := isc.mutation.InjectIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/ent/injectsubmission_update.go
+++ b/pkg/ent/injectsubmission_update.go
@@ -48,6 +48,34 @@ func (isu *InjectSubmissionUpdate) AppendFiles(s []structs.File) *InjectSubmissi
 	return isu
 }
 
+// SetNotes sets the "notes" field.
+func (isu *InjectSubmissionUpdate) SetNotes(s string) *InjectSubmissionUpdate {
+	isu.mutation.SetNotes(s)
+	return isu
+}
+
+// SetNillableNotes sets the "notes" field if the given value is not nil.
+func (isu *InjectSubmissionUpdate) SetNillableNotes(s *string) *InjectSubmissionUpdate {
+	if s != nil {
+		isu.SetNotes(*s)
+	}
+	return isu
+}
+
+// SetRubric sets the "rubric" field.
+func (isu *InjectSubmissionUpdate) SetRubric(s structs.Rubric) *InjectSubmissionUpdate {
+	isu.mutation.SetRubric(s)
+	return isu
+}
+
+// SetNillableRubric sets the "rubric" field if the given value is not nil.
+func (isu *InjectSubmissionUpdate) SetNillableRubric(s *structs.Rubric) *InjectSubmissionUpdate {
+	if s != nil {
+		isu.SetRubric(*s)
+	}
+	return isu
+}
+
 // Mutation returns the InjectSubmissionMutation object of the builder.
 func (isu *InjectSubmissionUpdate) Mutation() *InjectSubmissionMutation {
 	return isu.mutation
@@ -123,6 +151,12 @@ func (isu *InjectSubmissionUpdate) sqlSave(ctx context.Context) (n int, err erro
 			sqljson.Append(u, injectsubmission.FieldFiles, value)
 		})
 	}
+	if value, ok := isu.mutation.Notes(); ok {
+		_spec.SetField(injectsubmission.FieldNotes, field.TypeString, value)
+	}
+	if value, ok := isu.mutation.Rubric(); ok {
+		_spec.SetField(injectsubmission.FieldRubric, field.TypeJSON, value)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, isu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{injectsubmission.Label}
@@ -158,6 +192,34 @@ func (isuo *InjectSubmissionUpdateOne) SetFiles(s []structs.File) *InjectSubmiss
 // AppendFiles appends s to the "files" field.
 func (isuo *InjectSubmissionUpdateOne) AppendFiles(s []structs.File) *InjectSubmissionUpdateOne {
 	isuo.mutation.AppendFiles(s)
+	return isuo
+}
+
+// SetNotes sets the "notes" field.
+func (isuo *InjectSubmissionUpdateOne) SetNotes(s string) *InjectSubmissionUpdateOne {
+	isuo.mutation.SetNotes(s)
+	return isuo
+}
+
+// SetNillableNotes sets the "notes" field if the given value is not nil.
+func (isuo *InjectSubmissionUpdateOne) SetNillableNotes(s *string) *InjectSubmissionUpdateOne {
+	if s != nil {
+		isuo.SetNotes(*s)
+	}
+	return isuo
+}
+
+// SetRubric sets the "rubric" field.
+func (isuo *InjectSubmissionUpdateOne) SetRubric(s structs.Rubric) *InjectSubmissionUpdateOne {
+	isuo.mutation.SetRubric(s)
+	return isuo
+}
+
+// SetNillableRubric sets the "rubric" field if the given value is not nil.
+func (isuo *InjectSubmissionUpdateOne) SetNillableRubric(s *structs.Rubric) *InjectSubmissionUpdateOne {
+	if s != nil {
+		isuo.SetRubric(*s)
+	}
 	return isuo
 }
 
@@ -265,6 +327,12 @@ func (isuo *InjectSubmissionUpdateOne) sqlSave(ctx context.Context) (_node *Inje
 		_spec.AddModifier(func(u *sql.UpdateBuilder) {
 			sqljson.Append(u, injectsubmission.FieldFiles, value)
 		})
+	}
+	if value, ok := isuo.mutation.Notes(); ok {
+		_spec.SetField(injectsubmission.FieldNotes, field.TypeString, value)
+	}
+	if value, ok := isuo.mutation.Rubric(); ok {
+		_spec.SetField(injectsubmission.FieldRubric, field.TypeJSON, value)
 	}
 	_node = &InjectSubmission{config: isuo.config}
 	_spec.Assign = _node.assignValues

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -77,6 +77,7 @@ var (
 		{Name: "start_time", Type: field.TypeTime},
 		{Name: "end_time", Type: field.TypeTime},
 		{Name: "files", Type: field.TypeJSON},
+		{Name: "rubric", Type: field.TypeJSON},
 	}
 	// InjectsTable holds the schema information for the "injects" table.
 	InjectsTable = &schema.Table{
@@ -97,6 +98,8 @@ var (
 		{Name: "create_time", Type: field.TypeTime},
 		{Name: "update_time", Type: field.TypeTime},
 		{Name: "files", Type: field.TypeJSON},
+		{Name: "notes", Type: field.TypeString},
+		{Name: "rubric", Type: field.TypeJSON},
 		{Name: "inject_id", Type: field.TypeUUID},
 		{Name: "user_id", Type: field.TypeUUID},
 	}
@@ -108,13 +111,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "inject_submissions_injects_submissions",
-				Columns:    []*schema.Column{InjectSubmissionsColumns[4]},
+				Columns:    []*schema.Column{InjectSubmissionsColumns[6]},
 				RefColumns: []*schema.Column{InjectsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "inject_submissions_users_submissions",
-				Columns:    []*schema.Column{InjectSubmissionsColumns[5]},
+				Columns:    []*schema.Column{InjectSubmissionsColumns[7]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -1588,6 +1588,7 @@ type InjectMutation struct {
 	end_time           *time.Time
 	files              *[]structs.File
 	appendfiles        []structs.File
+	rubric             *structs.Rubric
 	clearedFields      map[string]struct{}
 	submissions        map[uuid.UUID]struct{}
 	removedsubmissions map[uuid.UUID]struct{}
@@ -1932,6 +1933,42 @@ func (m *InjectMutation) ResetFiles() {
 	m.appendfiles = nil
 }
 
+// SetRubric sets the "rubric" field.
+func (m *InjectMutation) SetRubric(s structs.Rubric) {
+	m.rubric = &s
+}
+
+// Rubric returns the value of the "rubric" field in the mutation.
+func (m *InjectMutation) Rubric() (r structs.Rubric, exists bool) {
+	v := m.rubric
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRubric returns the old "rubric" field's value of the Inject entity.
+// If the Inject object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *InjectMutation) OldRubric(ctx context.Context) (v structs.Rubric, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRubric is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRubric requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRubric: %w", err)
+	}
+	return oldValue.Rubric, nil
+}
+
+// ResetRubric resets all changes to the "rubric" field.
+func (m *InjectMutation) ResetRubric() {
+	m.rubric = nil
+}
+
 // AddSubmissionIDs adds the "submissions" edge to the InjectSubmission entity by ids.
 func (m *InjectMutation) AddSubmissionIDs(ids ...uuid.UUID) {
 	if m.submissions == nil {
@@ -2020,7 +2057,7 @@ func (m *InjectMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *InjectMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.create_time != nil {
 		fields = append(fields, inject.FieldCreateTime)
 	}
@@ -2038,6 +2075,9 @@ func (m *InjectMutation) Fields() []string {
 	}
 	if m.files != nil {
 		fields = append(fields, inject.FieldFiles)
+	}
+	if m.rubric != nil {
+		fields = append(fields, inject.FieldRubric)
 	}
 	return fields
 }
@@ -2059,6 +2099,8 @@ func (m *InjectMutation) Field(name string) (ent.Value, bool) {
 		return m.EndTime()
 	case inject.FieldFiles:
 		return m.Files()
+	case inject.FieldRubric:
+		return m.Rubric()
 	}
 	return nil, false
 }
@@ -2080,6 +2122,8 @@ func (m *InjectMutation) OldField(ctx context.Context, name string) (ent.Value, 
 		return m.OldEndTime(ctx)
 	case inject.FieldFiles:
 		return m.OldFiles(ctx)
+	case inject.FieldRubric:
+		return m.OldRubric(ctx)
 	}
 	return nil, fmt.Errorf("unknown Inject field %s", name)
 }
@@ -2130,6 +2174,13 @@ func (m *InjectMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetFiles(v)
+		return nil
+	case inject.FieldRubric:
+		v, ok := value.(structs.Rubric)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRubric(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Inject field %s", name)
@@ -2197,6 +2248,9 @@ func (m *InjectMutation) ResetField(name string) error {
 		return nil
 	case inject.FieldFiles:
 		m.ResetFiles()
+		return nil
+	case inject.FieldRubric:
+		m.ResetRubric()
 		return nil
 	}
 	return fmt.Errorf("unknown Inject field %s", name)
@@ -2296,6 +2350,8 @@ type InjectSubmissionMutation struct {
 	update_time   *time.Time
 	files         *[]structs.File
 	appendfiles   []structs.File
+	notes         *string
+	rubric        *structs.Rubric
 	clearedFields map[string]struct{}
 	inject        *uuid.UUID
 	clearedinject bool
@@ -2605,6 +2661,78 @@ func (m *InjectSubmissionMutation) ResetUserID() {
 	m.user = nil
 }
 
+// SetNotes sets the "notes" field.
+func (m *InjectSubmissionMutation) SetNotes(s string) {
+	m.notes = &s
+}
+
+// Notes returns the value of the "notes" field in the mutation.
+func (m *InjectSubmissionMutation) Notes() (r string, exists bool) {
+	v := m.notes
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNotes returns the old "notes" field's value of the InjectSubmission entity.
+// If the InjectSubmission object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *InjectSubmissionMutation) OldNotes(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNotes is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNotes requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNotes: %w", err)
+	}
+	return oldValue.Notes, nil
+}
+
+// ResetNotes resets all changes to the "notes" field.
+func (m *InjectSubmissionMutation) ResetNotes() {
+	m.notes = nil
+}
+
+// SetRubric sets the "rubric" field.
+func (m *InjectSubmissionMutation) SetRubric(s structs.Rubric) {
+	m.rubric = &s
+}
+
+// Rubric returns the value of the "rubric" field in the mutation.
+func (m *InjectSubmissionMutation) Rubric() (r structs.Rubric, exists bool) {
+	v := m.rubric
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRubric returns the old "rubric" field's value of the InjectSubmission entity.
+// If the InjectSubmission object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *InjectSubmissionMutation) OldRubric(ctx context.Context) (v structs.Rubric, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRubric is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRubric requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRubric: %w", err)
+	}
+	return oldValue.Rubric, nil
+}
+
+// ResetRubric resets all changes to the "rubric" field.
+func (m *InjectSubmissionMutation) ResetRubric() {
+	m.rubric = nil
+}
+
 // ClearInject clears the "inject" edge to the Inject entity.
 func (m *InjectSubmissionMutation) ClearInject() {
 	m.clearedinject = true
@@ -2693,7 +2821,7 @@ func (m *InjectSubmissionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *InjectSubmissionMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 7)
 	if m.create_time != nil {
 		fields = append(fields, injectsubmission.FieldCreateTime)
 	}
@@ -2708,6 +2836,12 @@ func (m *InjectSubmissionMutation) Fields() []string {
 	}
 	if m.user != nil {
 		fields = append(fields, injectsubmission.FieldUserID)
+	}
+	if m.notes != nil {
+		fields = append(fields, injectsubmission.FieldNotes)
+	}
+	if m.rubric != nil {
+		fields = append(fields, injectsubmission.FieldRubric)
 	}
 	return fields
 }
@@ -2727,6 +2861,10 @@ func (m *InjectSubmissionMutation) Field(name string) (ent.Value, bool) {
 		return m.InjectID()
 	case injectsubmission.FieldUserID:
 		return m.UserID()
+	case injectsubmission.FieldNotes:
+		return m.Notes()
+	case injectsubmission.FieldRubric:
+		return m.Rubric()
 	}
 	return nil, false
 }
@@ -2746,6 +2884,10 @@ func (m *InjectSubmissionMutation) OldField(ctx context.Context, name string) (e
 		return m.OldInjectID(ctx)
 	case injectsubmission.FieldUserID:
 		return m.OldUserID(ctx)
+	case injectsubmission.FieldNotes:
+		return m.OldNotes(ctx)
+	case injectsubmission.FieldRubric:
+		return m.OldRubric(ctx)
 	}
 	return nil, fmt.Errorf("unknown InjectSubmission field %s", name)
 }
@@ -2789,6 +2931,20 @@ func (m *InjectSubmissionMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUserID(v)
+		return nil
+	case injectsubmission.FieldNotes:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNotes(v)
+		return nil
+	case injectsubmission.FieldRubric:
+		v, ok := value.(structs.Rubric)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRubric(v)
 		return nil
 	}
 	return fmt.Errorf("unknown InjectSubmission field %s", name)
@@ -2853,6 +3009,12 @@ func (m *InjectSubmissionMutation) ResetField(name string) error {
 		return nil
 	case injectsubmission.FieldUserID:
 		m.ResetUserID()
+		return nil
+	case injectsubmission.FieldNotes:
+		m.ResetNotes()
+		return nil
+	case injectsubmission.FieldRubric:
+		m.ResetRubric()
 		return nil
 	}
 	return fmt.Errorf("unknown InjectSubmission field %s", name)

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -1588,7 +1588,7 @@ type InjectMutation struct {
 	end_time           *time.Time
 	files              *[]structs.File
 	appendfiles        []structs.File
-	rubric             *structs.Rubric
+	rubric             *structs.RubricTemplate
 	clearedFields      map[string]struct{}
 	submissions        map[uuid.UUID]struct{}
 	removedsubmissions map[uuid.UUID]struct{}
@@ -1934,12 +1934,12 @@ func (m *InjectMutation) ResetFiles() {
 }
 
 // SetRubric sets the "rubric" field.
-func (m *InjectMutation) SetRubric(s structs.Rubric) {
-	m.rubric = &s
+func (m *InjectMutation) SetRubric(st structs.RubricTemplate) {
+	m.rubric = &st
 }
 
 // Rubric returns the value of the "rubric" field in the mutation.
-func (m *InjectMutation) Rubric() (r structs.Rubric, exists bool) {
+func (m *InjectMutation) Rubric() (r structs.RubricTemplate, exists bool) {
 	v := m.rubric
 	if v == nil {
 		return
@@ -1950,7 +1950,7 @@ func (m *InjectMutation) Rubric() (r structs.Rubric, exists bool) {
 // OldRubric returns the old "rubric" field's value of the Inject entity.
 // If the Inject object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *InjectMutation) OldRubric(ctx context.Context) (v structs.Rubric, err error) {
+func (m *InjectMutation) OldRubric(ctx context.Context) (v structs.RubricTemplate, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldRubric is only allowed on UpdateOne operations")
 	}
@@ -2176,7 +2176,7 @@ func (m *InjectMutation) SetField(name string, value ent.Value) error {
 		m.SetFiles(v)
 		return nil
 	case inject.FieldRubric:
-		v, ok := value.(structs.Rubric)
+		v, ok := value.(structs.RubricTemplate)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}

--- a/pkg/ent/schema/inject.go
+++ b/pkg/ent/schema/inject.go
@@ -39,7 +39,7 @@ func (Inject) Fields() []ent.Field {
 		field.JSON("files", []structs.File{}).
 			StructTag(`json:"files"`).
 			Comment("The files of the inject"),
-		field.JSON("rubric", structs.Rubric{}).
+		field.JSON("rubric", structs.RubricTemplate{}).
 			StructTag(`json:"rubric"`).
 			Comment("The rubric of the inject"),
 	}

--- a/pkg/ent/schema/inject.go
+++ b/pkg/ent/schema/inject.go
@@ -39,6 +39,9 @@ func (Inject) Fields() []ent.Field {
 		field.JSON("files", []structs.File{}).
 			StructTag(`json:"files"`).
 			Comment("The files of the inject"),
+		field.JSON("rubric", structs.Rubric{}).
+			StructTag(`json:"rubric"`).
+			Comment("The rubric of the inject"),
 	}
 }
 

--- a/pkg/ent/schema/injectsubmission.go
+++ b/pkg/ent/schema/injectsubmission.go
@@ -34,6 +34,12 @@ func (InjectSubmission) Fields() []ent.Field {
 			StructTag(`json:"user_id"`).
 			Comment("The user this submission belongs to").
 			Immutable(),
+		field.String("notes").
+			StructTag(`json:"notes"`).
+			Comment("The notes of the inject submission"),
+		field.JSON("rubric", structs.Rubric{}).
+			StructTag(`json:"rubric"`).
+			Comment("The rubric of the inject submission"),
 	}
 }
 

--- a/pkg/structs/rubric.go
+++ b/pkg/structs/rubric.go
@@ -22,4 +22,5 @@ type Rubric struct {
 	Score    int           `json:"score"`
 	MaxScore int           `json:"max_score"`
 	Notes    string        `json:"notes"`
+	Graded   bool          `json:"graded"`
 }

--- a/pkg/structs/rubric.go
+++ b/pkg/structs/rubric.go
@@ -1,0 +1,15 @@
+package structs
+
+type RubricField struct {
+	Name     string `json:"name"`
+	Score    int    `json:"score"`
+	MaxScore int    `json:"max_score"`
+	Notes    string `json:"notes"`
+}
+
+type Rubric struct {
+	Fields   []RubricField `json:"fields"`
+	Score    int           `json:"score"`
+	MaxScore int           `json:"max_score"`
+	Notes    string        `json:"notes"`
+}

--- a/pkg/structs/rubric.go
+++ b/pkg/structs/rubric.go
@@ -1,5 +1,15 @@
 package structs
 
+type RubricTemplateField struct {
+	Name     string `json:"name"`
+	MaxScore int    `json:"max_score"`
+}
+
+type RubricTemplate struct {
+	Fields   []RubricTemplateField `json:"fields"`
+	MaxScore int                   `json:"max_score"`
+}
+
 type RubricField struct {
 	Name     string `json:"name"`
 	Score    int    `json:"score"`


### PR DESCRIPTION
### TL;DR

This pull request adds two new fields to the `Inject` and `InjectSubmission` schemas: `rubric` and `notes`.

### What changed?

In the `Inject` schema, a new JSON field `rubric` has been added that uses the newly created `structs.Rubric` struct. Similarly, in the `InjectSubmission` schema, a new JSON field `rubric` and a string field `notes` have been added.

### How to test?

You can test these changes by running the schema generation and ensuring the new fields are present and correctly associated with the correct schemas.

### Why make this change?

These changes allow us to capture and store more information about the injects and their submissions, including any specific rubric that may be used for grading purposes and any notes associated with the inject submission.

---

Add Rubric and RubricField structs

This commit adds the Rubric and RubricField structs to the project. These structs are used to represent rubrics and their fields, including the name, score, max score, and notes. This addition will enable the implementation of rubric functionality in the application.

Add rubric field to inject schema

Add notes and rubric fields to inject submission schema