### PR TITLE
Implement Rubric Usage in GraphQL

### DIFF
--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -54,6 +54,7 @@ type ResolverRoot interface {
 	Mutation() MutationResolver
 	Query() QueryResolver
 	Round() RoundResolver
+	RubricField() RubricFieldResolver
 	ScoreCache() ScoreCacheResolver
 	Status() StatusResolver
 	Subscription() SubscriptionResolver
@@ -305,7 +306,6 @@ type InjectSubmissionResolver interface {
 
 	User(ctx context.Context, obj *ent.InjectSubmission) (*ent.User, error)
 	Inject(ctx context.Context, obj *ent.InjectSubmission) (*ent.Inject, error)
-	Rubric(ctx context.Context, obj *ent.InjectSubmission) (*model.Rubric, error)
 }
 type MutationResolver interface {
 	Login(ctx context.Context, username string, password string) (*model.LoginOutput, error)
@@ -345,6 +345,9 @@ type QueryResolver interface {
 type RoundResolver interface {
 	Statuses(ctx context.Context, obj *ent.Round) ([]*ent.Status, error)
 	ScoreCaches(ctx context.Context, obj *ent.Round) ([]*ent.ScoreCache, error)
+}
+type RubricFieldResolver interface {
+	MaxScore(ctx context.Context, obj *structs.RubricField) (int, error)
 }
 type ScoreCacheResolver interface {
 	Round(ctx context.Context, obj *ent.ScoreCache) (*ent.Round, error)
@@ -4452,7 +4455,7 @@ func (ec *executionContext) _InjectSubmission_rubric(ctx context.Context, field 
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.InjectSubmission().Rubric(rctx, obj)
+		return obj.Rubric, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4464,17 +4467,17 @@ func (ec *executionContext) _InjectSubmission_rubric(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*model.Rubric)
+	res := resTmp.(structs.Rubric)
 	fc.Result = res
-	return ec.marshalNRubric2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubric(ctx, field.Selections, res)
+	return ec.marshalNRubric2githubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubric(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_InjectSubmission_rubric(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "InjectSubmission",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "fields":
@@ -7964,7 +7967,7 @@ func (ec *executionContext) fieldContext_Round_score_caches(ctx context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _Rubric_fields(ctx context.Context, field graphql.CollectedField, obj *model.Rubric) (ret graphql.Marshaler) {
+func (ec *executionContext) _Rubric_fields(ctx context.Context, field graphql.CollectedField, obj *structs.Rubric) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Rubric_fields(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -7990,9 +7993,9 @@ func (ec *executionContext) _Rubric_fields(ctx context.Context, field graphql.Co
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.RubricField)
+	res := resTmp.([]structs.RubricField)
 	fc.Result = res
-	return ec.marshalNRubricField2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricFieldᚄ(ctx, field.Selections, res)
+	return ec.marshalNRubricField2ᚕgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubricFieldᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Rubric_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -8018,7 +8021,7 @@ func (ec *executionContext) fieldContext_Rubric_fields(ctx context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _Rubric_notes(ctx context.Context, field graphql.CollectedField, obj *model.Rubric) (ret graphql.Marshaler) {
+func (ec *executionContext) _Rubric_notes(ctx context.Context, field graphql.CollectedField, obj *structs.Rubric) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Rubric_notes(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -8041,9 +8044,9 @@ func (ec *executionContext) _Rubric_notes(ctx context.Context, field graphql.Col
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Rubric_notes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -8059,7 +8062,7 @@ func (ec *executionContext) fieldContext_Rubric_notes(ctx context.Context, field
 	return fc, nil
 }
 
-func (ec *executionContext) _RubricField_name(ctx context.Context, field graphql.CollectedField, obj *model.RubricField) (ret graphql.Marshaler) {
+func (ec *executionContext) _RubricField_name(ctx context.Context, field graphql.CollectedField, obj *structs.RubricField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RubricField_name(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -8103,7 +8106,7 @@ func (ec *executionContext) fieldContext_RubricField_name(ctx context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _RubricField_score(ctx context.Context, field graphql.CollectedField, obj *model.RubricField) (ret graphql.Marshaler) {
+func (ec *executionContext) _RubricField_score(ctx context.Context, field graphql.CollectedField, obj *structs.RubricField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RubricField_score(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -8147,7 +8150,7 @@ func (ec *executionContext) fieldContext_RubricField_score(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _RubricField_max_score(ctx context.Context, field graphql.CollectedField, obj *model.RubricField) (ret graphql.Marshaler) {
+func (ec *executionContext) _RubricField_max_score(ctx context.Context, field graphql.CollectedField, obj *structs.RubricField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RubricField_max_score(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -8161,7 +8164,7 @@ func (ec *executionContext) _RubricField_max_score(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.MaxScore, nil
+		return ec.resolvers.RubricField().MaxScore(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8182,8 +8185,8 @@ func (ec *executionContext) fieldContext_RubricField_max_score(ctx context.Conte
 	fc = &graphql.FieldContext{
 		Object:     "RubricField",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
 		},
@@ -8191,7 +8194,7 @@ func (ec *executionContext) fieldContext_RubricField_max_score(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _RubricField_notes(ctx context.Context, field graphql.CollectedField, obj *model.RubricField) (ret graphql.Marshaler) {
+func (ec *executionContext) _RubricField_notes(ctx context.Context, field graphql.CollectedField, obj *structs.RubricField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RubricField_notes(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -8214,9 +8217,9 @@ func (ec *executionContext) _RubricField_notes(ctx context.Context, field graphq
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_RubricField_notes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -13553,41 +13556,10 @@ func (ec *executionContext) _InjectSubmission(ctx context.Context, sel ast.Selec
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "rubric":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._InjectSubmission_rubric(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._InjectSubmission_rubric(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "graded":
 			out.Values[i] = ec._InjectSubmission_graded(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -14363,7 +14335,7 @@ func (ec *executionContext) _Round(ctx context.Context, sel ast.SelectionSet, ob
 
 var rubricImplementors = []string{"Rubric"}
 
-func (ec *executionContext) _Rubric(ctx context.Context, sel ast.SelectionSet, obj *model.Rubric) graphql.Marshaler {
+func (ec *executionContext) _Rubric(ctx context.Context, sel ast.SelectionSet, obj *structs.Rubric) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, rubricImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -14404,7 +14376,7 @@ func (ec *executionContext) _Rubric(ctx context.Context, sel ast.SelectionSet, o
 
 var rubricFieldImplementors = []string{"RubricField"}
 
-func (ec *executionContext) _RubricField(ctx context.Context, sel ast.SelectionSet, obj *model.RubricField) graphql.Marshaler {
+func (ec *executionContext) _RubricField(ctx context.Context, sel ast.SelectionSet, obj *structs.RubricField) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, rubricFieldImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -14416,18 +14388,49 @@ func (ec *executionContext) _RubricField(ctx context.Context, sel ast.SelectionS
 		case "name":
 			out.Values[i] = ec._RubricField_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "score":
 			out.Values[i] = ec._RubricField_score(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "max_score":
-			out.Values[i] = ec._RubricField_max_score(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._RubricField_max_score(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "notes":
 			out.Values[i] = ec._RubricField_notes(ctx, field, obj)
 		default:
@@ -16043,21 +16046,15 @@ func (ec *executionContext) marshalNRound2ᚖgithubᚗcomᚋscorifyᚋbackendᚋ
 	return ec._Round(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNRubric2githubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubric(ctx context.Context, sel ast.SelectionSet, v model.Rubric) graphql.Marshaler {
+func (ec *executionContext) marshalNRubric2githubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubric(ctx context.Context, sel ast.SelectionSet, v structs.Rubric) graphql.Marshaler {
 	return ec._Rubric(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNRubric2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubric(ctx context.Context, sel ast.SelectionSet, v *model.Rubric) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._Rubric(ctx, sel, v)
+func (ec *executionContext) marshalNRubricField2githubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubricField(ctx context.Context, sel ast.SelectionSet, v structs.RubricField) graphql.Marshaler {
+	return ec._RubricField(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNRubricField2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.RubricField) graphql.Marshaler {
+func (ec *executionContext) marshalNRubricField2ᚕgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubricFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []structs.RubricField) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -16081,7 +16078,7 @@ func (ec *executionContext) marshalNRubricField2ᚕᚖgithubᚗcomᚋscorifyᚋb
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNRubricField2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricField(ctx, sel, v[i])
+			ret[i] = ec.marshalNRubricField2githubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubricField(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -16099,16 +16096,6 @@ func (ec *executionContext) marshalNRubricField2ᚕᚖgithubᚗcomᚋscorifyᚋb
 	}
 
 	return ret
-}
-
-func (ec *executionContext) marshalNRubricField2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricField(ctx context.Context, sel ast.SelectionSet, v *model.RubricField) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._RubricField(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNRubricFieldInput2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricFieldInputᚄ(ctx context.Context, v interface{}) ([]*model.RubricFieldInput, error) {

--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -54,7 +54,6 @@ type ResolverRoot interface {
 	Mutation() MutationResolver
 	Query() QueryResolver
 	Round() RoundResolver
-	RubricField() RubricFieldResolver
 	ScoreCache() ScoreCacheResolver
 	Status() StatusResolver
 	Subscription() SubscriptionResolver
@@ -197,10 +196,9 @@ type ComplexityRoot struct {
 	}
 
 	RubricField struct {
-		MaxScore func(childComplexity int) int
-		Name     func(childComplexity int) int
-		Notes    func(childComplexity int) int
-		Score    func(childComplexity int) int
+		Name  func(childComplexity int) int
+		Notes func(childComplexity int) int
+		Score func(childComplexity int) int
 	}
 
 	RubricTemplate struct {
@@ -345,9 +343,6 @@ type QueryResolver interface {
 type RoundResolver interface {
 	Statuses(ctx context.Context, obj *ent.Round) ([]*ent.Status, error)
 	ScoreCaches(ctx context.Context, obj *ent.Round) ([]*ent.ScoreCache, error)
-}
-type RubricFieldResolver interface {
-	MaxScore(ctx context.Context, obj *structs.RubricField) (int, error)
 }
 type ScoreCacheResolver interface {
 	Round(ctx context.Context, obj *ent.ScoreCache) (*ent.Round, error)
@@ -1150,13 +1145,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Rubric.Notes(childComplexity), true
-
-	case "RubricField.max_score":
-		if e.complexity.RubricField.MaxScore == nil {
-			break
-		}
-
-		return e.complexity.RubricField.MaxScore(childComplexity), true
 
 	case "RubricField.name":
 		if e.complexity.RubricField.Name == nil {
@@ -8010,8 +7998,6 @@ func (ec *executionContext) fieldContext_Rubric_fields(ctx context.Context, fiel
 				return ec.fieldContext_RubricField_name(ctx, field)
 			case "score":
 				return ec.fieldContext_RubricField_score(ctx, field)
-			case "max_score":
-				return ec.fieldContext_RubricField_max_score(ctx, field)
 			case "notes":
 				return ec.fieldContext_RubricField_notes(ctx, field)
 			}
@@ -8143,50 +8129,6 @@ func (ec *executionContext) fieldContext_RubricField_score(ctx context.Context, 
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Int does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _RubricField_max_score(ctx context.Context, field graphql.CollectedField, obj *structs.RubricField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_RubricField_max_score(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.RubricField().MaxScore(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_RubricField_max_score(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "RubricField",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
 		},
@@ -14388,49 +14330,13 @@ func (ec *executionContext) _RubricField(ctx context.Context, sel ast.SelectionS
 		case "name":
 			out.Values[i] = ec._RubricField_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		case "score":
 			out.Values[i] = ec._RubricField_score(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
-		case "max_score":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._RubricField_max_score(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "notes":
 			out.Values[i] = ec._RubricField_notes(ctx, field, obj)
 		default:

--- a/pkg/graph/generated.go
+++ b/pkg/graph/generated.go
@@ -54,7 +54,6 @@ type ResolverRoot interface {
 	Mutation() MutationResolver
 	Query() QueryResolver
 	Round() RoundResolver
-	RubricTemplate() RubricTemplateResolver
 	ScoreCache() ScoreCacheResolver
 	Status() StatusResolver
 	Subscription() SubscriptionResolver
@@ -346,9 +345,6 @@ type QueryResolver interface {
 type RoundResolver interface {
 	Statuses(ctx context.Context, obj *ent.Round) ([]*ent.Status, error)
 	ScoreCaches(ctx context.Context, obj *ent.Round) ([]*ent.ScoreCache, error)
-}
-type RubricTemplateResolver interface {
-	Fields(ctx context.Context, obj *structs.RubricTemplate) ([]*model.RubricTemplateField, error)
 }
 type ScoreCacheResolver interface {
 	Round(ctx context.Context, obj *ent.ScoreCache) (*ent.Round, error)
@@ -8250,7 +8246,7 @@ func (ec *executionContext) _RubricTemplate_fields(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.RubricTemplate().Fields(rctx, obj)
+		return obj.Fields, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -8262,17 +8258,17 @@ func (ec *executionContext) _RubricTemplate_fields(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*model.RubricTemplateField)
+	res := resTmp.([]structs.RubricTemplateField)
 	fc.Result = res
-	return ec.marshalNRubricTemplateField2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricTemplateFieldᚄ(ctx, field.Selections, res)
+	return ec.marshalNRubricTemplateField2ᚕgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubricTemplateFieldᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_RubricTemplate_fields(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "RubricTemplate",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "name":
@@ -8330,7 +8326,7 @@ func (ec *executionContext) fieldContext_RubricTemplate_max_score(ctx context.Co
 	return fc, nil
 }
 
-func (ec *executionContext) _RubricTemplateField_name(ctx context.Context, field graphql.CollectedField, obj *model.RubricTemplateField) (ret graphql.Marshaler) {
+func (ec *executionContext) _RubricTemplateField_name(ctx context.Context, field graphql.CollectedField, obj *structs.RubricTemplateField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RubricTemplateField_name(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -8374,7 +8370,7 @@ func (ec *executionContext) fieldContext_RubricTemplateField_name(ctx context.Co
 	return fc, nil
 }
 
-func (ec *executionContext) _RubricTemplateField_max_score(ctx context.Context, field graphql.CollectedField, obj *model.RubricTemplateField) (ret graphql.Marshaler) {
+func (ec *executionContext) _RubricTemplateField_max_score(ctx context.Context, field graphql.CollectedField, obj *structs.RubricTemplateField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RubricTemplateField_max_score(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -14469,45 +14465,14 @@ func (ec *executionContext) _RubricTemplate(ctx context.Context, sel ast.Selecti
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("RubricTemplate")
 		case "fields":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._RubricTemplate_fields(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._RubricTemplate_fields(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "max_score":
 			out.Values[i] = ec._RubricTemplate_max_score(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -14534,7 +14499,7 @@ func (ec *executionContext) _RubricTemplate(ctx context.Context, sel ast.Selecti
 
 var rubricTemplateFieldImplementors = []string{"RubricTemplateField"}
 
-func (ec *executionContext) _RubricTemplateField(ctx context.Context, sel ast.SelectionSet, obj *model.RubricTemplateField) graphql.Marshaler {
+func (ec *executionContext) _RubricTemplateField(ctx context.Context, sel ast.SelectionSet, obj *structs.RubricTemplateField) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, rubricTemplateFieldImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -16172,7 +16137,11 @@ func (ec *executionContext) marshalNRubricTemplate2githubᚗcomᚋscorifyᚋback
 	return ec._RubricTemplate(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNRubricTemplateField2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricTemplateFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.RubricTemplateField) graphql.Marshaler {
+func (ec *executionContext) marshalNRubricTemplateField2githubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubricTemplateField(ctx context.Context, sel ast.SelectionSet, v structs.RubricTemplateField) graphql.Marshaler {
+	return ec._RubricTemplateField(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNRubricTemplateField2ᚕgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubricTemplateFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []structs.RubricTemplateField) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -16196,7 +16165,7 @@ func (ec *executionContext) marshalNRubricTemplateField2ᚕᚖgithubᚗcomᚋsco
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNRubricTemplateField2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricTemplateField(ctx, sel, v[i])
+			ret[i] = ec.marshalNRubricTemplateField2githubᚗcomᚋscorifyᚋbackendᚋpkgᚋstructsᚐRubricTemplateField(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -16214,16 +16183,6 @@ func (ec *executionContext) marshalNRubricTemplateField2ᚕᚖgithubᚗcomᚋsco
 	}
 
 	return ret
-}
-
-func (ec *executionContext) marshalNRubricTemplateField2ᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricTemplateField(ctx context.Context, sel ast.SelectionSet, v *model.RubricTemplateField) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._RubricTemplateField(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNRubricTemplateFieldInput2ᚕᚖgithubᚗcomᚋscorifyᚋbackendᚋpkgᚋgraphᚋmodelᚐRubricTemplateFieldInputᚄ(ctx context.Context, v interface{}) ([]*model.RubricTemplateFieldInput, error) {

--- a/pkg/graph/gqlgen.yml
+++ b/pkg/graph/gqlgen.yml
@@ -108,3 +108,11 @@ models:
     model:
       - github.com/scorify/backend/pkg/structs.RubricTemplateField
 
+  Rubric:
+    model:
+      - github.com/scorify/backend/pkg/structs.Rubric
+  
+  RubricField:
+    model:
+      - github.com/scorify/backend/pkg/structs.RubricField
+

--- a/pkg/graph/gqlgen.yml
+++ b/pkg/graph/gqlgen.yml
@@ -99,4 +99,8 @@ models:
   StatusEnum:
     model:
       - github.com/scorify/backend/pkg/ent/status.Status
+  
+  RubricTemplate:
+   model:
+     - github.com/scorify/backend/pkg/structs.RubricTemplate
 

--- a/pkg/graph/gqlgen.yml
+++ b/pkg/graph/gqlgen.yml
@@ -103,4 +103,8 @@ models:
   RubricTemplate:
    model:
      - github.com/scorify/backend/pkg/structs.RubricTemplate
+    
+  RubricTemplateField:
+    model:
+      - github.com/scorify/backend/pkg/structs.RubricTemplateField
 

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -32,18 +32,6 @@ type Notification struct {
 	Type    NotificationType `json:"type"`
 }
 
-type Rubric struct {
-	Fields []*RubricField `json:"fields"`
-	Notes  *string        `json:"notes,omitempty"`
-}
-
-type RubricField struct {
-	Name     string  `json:"name"`
-	Score    int     `json:"score"`
-	MaxScore int     `json:"max_score"`
-	Notes    *string `json:"notes,omitempty"`
-}
-
 type RubricFieldInput struct {
 	Name  string  `json:"name"`
 	Score int     `json:"score"`

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -33,10 +33,8 @@ type Notification struct {
 }
 
 type Rubric struct {
-	Fields   []*RubricField `json:"fields"`
-	Score    int            `json:"score"`
-	MaxScore int            `json:"max_score"`
-	Notes    *string        `json:"notes,omitempty"`
+	Fields []*RubricField `json:"fields"`
+	Notes  *string        `json:"notes,omitempty"`
 }
 
 type RubricField struct {
@@ -47,10 +45,9 @@ type RubricField struct {
 }
 
 type RubricFieldInput struct {
-	Name     string  `json:"name"`
-	Score    int     `json:"score"`
-	MaxScore int     `json:"max_score"`
-	Notes    *string `json:"notes,omitempty"`
+	Name  string  `json:"name"`
+	Score int     `json:"score"`
+	Notes *string `json:"notes,omitempty"`
 }
 
 type RubricInput struct {
@@ -58,11 +55,6 @@ type RubricInput struct {
 	Score    int                 `json:"score"`
 	MaxScore int                 `json:"max_score"`
 	Notes    *string             `json:"notes,omitempty"`
-}
-
-type RubricTemplate struct {
-	Fields   []*RubricTemplateField `json:"fields"`
-	MaxScore int                    `json:"max_score"`
 }
 
 type RubricTemplateField struct {

--- a/pkg/graph/model/models_gen.go
+++ b/pkg/graph/model/models_gen.go
@@ -57,11 +57,6 @@ type RubricInput struct {
 	Notes    *string             `json:"notes,omitempty"`
 }
 
-type RubricTemplateField struct {
-	Name     string `json:"name"`
-	MaxScore int    `json:"max_score"`
-}
-
 type RubricTemplateFieldInput struct {
 	Name     string `json:"name"`
 	MaxScore int    `json:"max_score"`

--- a/pkg/graph/schema.graphqls
+++ b/pkg/graph/schema.graphqls
@@ -155,7 +155,6 @@ input RubricTemplateInput {
 type RubricField {
   name: String!
   score: Int!
-  max_score: Int!
   notes: String
 }
 

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -162,11 +162,6 @@ func (r *injectSubmissionResolver) Inject(ctx context.Context, obj *ent.InjectSu
 	return obj.QueryInject().Only(ctx)
 }
 
-// Rubric is the resolver for the rubric field.
-func (r *injectSubmissionResolver) Rubric(ctx context.Context, obj *ent.InjectSubmission) (*model.Rubric, error) {
-	panic(fmt.Errorf("not implemented: Rubric - rubric"))
-}
-
 // Login is the resolver for the login field.
 func (r *mutationResolver) Login(ctx context.Context, username string, password string) (*model.LoginOutput, error) {
 	entUser, err := r.Ent.User.Query().
@@ -1231,6 +1226,11 @@ func (r *roundResolver) ScoreCaches(ctx context.Context, obj *ent.Round) ([]*ent
 		).All(ctx)
 }
 
+// MaxScore is the resolver for the max_score field.
+func (r *rubricFieldResolver) MaxScore(ctx context.Context, obj *structs.RubricField) (int, error) {
+	panic(fmt.Errorf("not implemented: MaxScore - max_score"))
+}
+
 // Round is the resolver for the round field.
 func (r *scoreCacheResolver) Round(ctx context.Context, obj *ent.ScoreCache) (*ent.Round, error) {
 	return obj.QueryRound().Only(ctx)
@@ -1428,6 +1428,9 @@ func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 // Round returns RoundResolver implementation.
 func (r *Resolver) Round() RoundResolver { return &roundResolver{r} }
 
+// RubricField returns RubricFieldResolver implementation.
+func (r *Resolver) RubricField() RubricFieldResolver { return &rubricFieldResolver{r} }
+
 // ScoreCache returns ScoreCacheResolver implementation.
 func (r *Resolver) ScoreCache() ScoreCacheResolver { return &scoreCacheResolver{r} }
 
@@ -1448,6 +1451,7 @@ type injectSubmissionResolver struct{ *Resolver }
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type roundResolver struct{ *Resolver }
+type rubricFieldResolver struct{ *Resolver }
 type scoreCacheResolver struct{ *Resolver }
 type statusResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -933,8 +933,7 @@ func (r *mutationResolver) CreateInject(ctx context.Context, title string, start
 
 // UpdateInject is the resolver for the updateInject field.
 func (r *mutationResolver) UpdateInject(ctx context.Context, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time, deleteFiles []uuid.UUID, addFiles []*graphql.Upload, rubric *model.RubricTemplateInput) (*ent.Inject, error) {
-	// TODO: Implement use of rubric
-	if title == nil && startTime == nil && endTime == nil && len(deleteFiles) == 0 && len(addFiles) == 0 {
+	if title == nil && startTime == nil && endTime == nil && len(deleteFiles) == 0 && len(addFiles) == 0 && rubric == nil {
 		return nil, fmt.Errorf("no fields to update")
 	}
 
@@ -1005,6 +1004,23 @@ func (r *mutationResolver) UpdateInject(ctx context.Context, id uuid.UUID, title
 
 	if len(deleteFiles) > 0 || len(addFiles) > 0 {
 		injectUpdate.SetFiles(entInject.Files)
+	}
+
+	if rubric != nil {
+		rubricTemplateFields := make([]structs.RubricTemplateField, len(rubric.Fields))
+		for i, field := range rubric.Fields {
+			rubricTemplateFields[i] = structs.RubricTemplateField{
+				Name:     field.Name,
+				MaxScore: field.MaxScore,
+			}
+		}
+
+		rubricTemplate := structs.RubricTemplate{
+			Fields:   rubricTemplateFields,
+			MaxScore: rubric.MaxScore,
+		}
+
+		injectUpdate.SetRubric(rubricTemplate)
 	}
 
 	return injectUpdate.Save(ctx)

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1226,11 +1226,6 @@ func (r *roundResolver) ScoreCaches(ctx context.Context, obj *ent.Round) ([]*ent
 		).All(ctx)
 }
 
-// MaxScore is the resolver for the max_score field.
-func (r *rubricFieldResolver) MaxScore(ctx context.Context, obj *structs.RubricField) (int, error) {
-	panic(fmt.Errorf("not implemented: MaxScore - max_score"))
-}
-
 // Round is the resolver for the round field.
 func (r *scoreCacheResolver) Round(ctx context.Context, obj *ent.ScoreCache) (*ent.Round, error) {
 	return obj.QueryRound().Only(ctx)
@@ -1428,9 +1423,6 @@ func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 // Round returns RoundResolver implementation.
 func (r *Resolver) Round() RoundResolver { return &roundResolver{r} }
 
-// RubricField returns RubricFieldResolver implementation.
-func (r *Resolver) RubricField() RubricFieldResolver { return &rubricFieldResolver{r} }
-
 // ScoreCache returns ScoreCacheResolver implementation.
 func (r *Resolver) ScoreCache() ScoreCacheResolver { return &scoreCacheResolver{r} }
 
@@ -1451,7 +1443,6 @@ type injectSubmissionResolver struct{ *Resolver }
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type roundResolver struct{ *Resolver }
-type rubricFieldResolver struct{ *Resolver }
 type scoreCacheResolver struct{ *Resolver }
 type statusResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -876,7 +876,6 @@ func (r *mutationResolver) StopEngine(ctx context.Context) (bool, error) {
 
 // CreateInject is the resolver for the createInject field.
 func (r *mutationResolver) CreateInject(ctx context.Context, title string, startTime time.Time, endTime time.Time, files []*graphql.Upload, rubric model.RubricTemplateInput) (*ent.Inject, error) {
-	// TODO: Implement use of rubric
 	structFiles := make([]structs.File, len(files))
 
 	for i, file := range files {
@@ -884,6 +883,19 @@ func (r *mutationResolver) CreateInject(ctx context.Context, title string, start
 			ID:   uuid.New(),
 			Name: file.Filename,
 		}
+	}
+
+	rubricTemplateFields := make([]structs.RubricTemplateField, len(rubric.Fields))
+	for i, field := range rubric.Fields {
+		rubricTemplateFields[i] = structs.RubricTemplateField{
+			Name:     field.Name,
+			MaxScore: field.MaxScore,
+		}
+	}
+
+	rubricTemplate := structs.RubricTemplate{
+		Fields:   rubricTemplateFields,
+		MaxScore: rubric.MaxScore,
 	}
 
 	tx, err := r.Ent.Tx(ctx)
@@ -898,6 +910,7 @@ func (r *mutationResolver) CreateInject(ctx context.Context, title string, start
 		SetStartTime(startTime).
 		SetEndTime(endTime).
 		SetFiles(structFiles).
+		SetRubric(rubricTemplate).
 		Save(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create inject: %v", err)

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -1231,11 +1231,6 @@ func (r *roundResolver) ScoreCaches(ctx context.Context, obj *ent.Round) ([]*ent
 		).All(ctx)
 }
 
-// Fields is the resolver for the fields field.
-func (r *rubricTemplateResolver) Fields(ctx context.Context, obj *structs.RubricTemplate) ([]*model.RubricTemplateField, error) {
-	panic(fmt.Errorf("not implemented: Fields - fields"))
-}
-
 // Round is the resolver for the round field.
 func (r *scoreCacheResolver) Round(ctx context.Context, obj *ent.ScoreCache) (*ent.Round, error) {
 	return obj.QueryRound().Only(ctx)
@@ -1433,9 +1428,6 @@ func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 // Round returns RoundResolver implementation.
 func (r *Resolver) Round() RoundResolver { return &roundResolver{r} }
 
-// RubricTemplate returns RubricTemplateResolver implementation.
-func (r *Resolver) RubricTemplate() RubricTemplateResolver { return &rubricTemplateResolver{r} }
-
 // ScoreCache returns ScoreCacheResolver implementation.
 func (r *Resolver) ScoreCache() ScoreCacheResolver { return &scoreCacheResolver{r} }
 
@@ -1456,7 +1448,6 @@ type injectSubmissionResolver struct{ *Resolver }
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type roundResolver struct{ *Resolver }
-type rubricTemplateResolver struct{ *Resolver }
 type scoreCacheResolver struct{ *Resolver }
 type statusResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }

--- a/pkg/graph/schema.resolvers.go
+++ b/pkg/graph/schema.resolvers.go
@@ -132,11 +132,6 @@ func (r *injectResolver) Submissions(ctx context.Context, obj *ent.Inject) ([]*e
 	return obj.QuerySubmissions().All(ctx)
 }
 
-// Rubric is the resolver for the rubric field.
-func (r *injectResolver) Rubric(ctx context.Context, obj *ent.Inject) (*model.RubricTemplate, error) {
-	panic(fmt.Errorf("not implemented: Rubric - rubric"))
-}
-
 // Files is the resolver for the files field.
 func (r *injectSubmissionResolver) Files(ctx context.Context, obj *ent.InjectSubmission) ([]*model.File, error) {
 	files := make([]*model.File, len(obj.Files))
@@ -886,6 +881,7 @@ func (r *mutationResolver) StopEngine(ctx context.Context) (bool, error) {
 
 // CreateInject is the resolver for the createInject field.
 func (r *mutationResolver) CreateInject(ctx context.Context, title string, startTime time.Time, endTime time.Time, files []*graphql.Upload, rubric model.RubricTemplateInput) (*ent.Inject, error) {
+	// TODO: Implement use of rubric
 	structFiles := make([]structs.File, len(files))
 
 	for i, file := range files {
@@ -929,6 +925,7 @@ func (r *mutationResolver) CreateInject(ctx context.Context, title string, start
 
 // UpdateInject is the resolver for the updateInject field.
 func (r *mutationResolver) UpdateInject(ctx context.Context, id uuid.UUID, title *string, startTime *time.Time, endTime *time.Time, deleteFiles []uuid.UUID, addFiles []*graphql.Upload, rubric *model.RubricTemplateInput) (*ent.Inject, error) {
+	// TODO: Implement use of rubric
 	if title == nil && startTime == nil && endTime == nil && len(deleteFiles) == 0 && len(addFiles) == 0 {
 		return nil, fmt.Errorf("no fields to update")
 	}
@@ -1234,6 +1231,11 @@ func (r *roundResolver) ScoreCaches(ctx context.Context, obj *ent.Round) ([]*ent
 		).All(ctx)
 }
 
+// Fields is the resolver for the fields field.
+func (r *rubricTemplateResolver) Fields(ctx context.Context, obj *structs.RubricTemplate) ([]*model.RubricTemplateField, error) {
+	panic(fmt.Errorf("not implemented: Fields - fields"))
+}
+
 // Round is the resolver for the round field.
 func (r *scoreCacheResolver) Round(ctx context.Context, obj *ent.ScoreCache) (*ent.Round, error) {
 	return obj.QueryRound().Only(ctx)
@@ -1431,6 +1433,9 @@ func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 // Round returns RoundResolver implementation.
 func (r *Resolver) Round() RoundResolver { return &roundResolver{r} }
 
+// RubricTemplate returns RubricTemplateResolver implementation.
+func (r *Resolver) RubricTemplate() RubricTemplateResolver { return &rubricTemplateResolver{r} }
+
 // ScoreCache returns ScoreCacheResolver implementation.
 func (r *Resolver) ScoreCache() ScoreCacheResolver { return &scoreCacheResolver{r} }
 
@@ -1451,6 +1456,7 @@ type injectSubmissionResolver struct{ *Resolver }
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type roundResolver struct{ *Resolver }
+type rubricTemplateResolver struct{ *Resolver }
 type scoreCacheResolver struct{ *Resolver }
 type statusResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }


### PR DESCRIPTION
Add RubricTemplate model to gqlgen.yml

gql generation

Add RubricTemplateField model to gqlgen.yml

gql generation

Add Rubric, RubricField, and RubricTemplate models to gqlgen.yml

gql generation

Refactor schema.resolvers.go to remove unused RubricFieldResolver

gql generation